### PR TITLE
Fix/get only non-sensitive user data

### DIFF
--- a/src/witan/app/handler.clj
+++ b/src/witan/app/handler.clj
@@ -52,7 +52,7 @@
 
 (defn check-user [identity]
   (if-let [user (user/retrieve-user identity)]
-    (ok user)
+    (ok (select-keys user [:id :username]))
     (unauthorized {:error "Unauthorized"})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/witan/app/handler.clj
+++ b/src/witan/app/handler.clj
@@ -52,7 +52,7 @@
 
 (defn check-user [identity]
   (if-let [user (user/retrieve-user identity)]
-    (ok (select-keys user [:id :username]))
+    (ok (select-keys user [:id :username :name]))
     (unauthorized {:error "Unauthorized"})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/witan/app/user.clj
+++ b/src/witan/app/user.clj
@@ -37,4 +37,4 @@
       false)))
 
 (defn retrieve-user [id]
-  ((exec) (find-user id)))
+  (first ((exec) (find-user id))))


### PR DESCRIPTION
the api should never provide the password hash. only white-listed data.
It also only ever returns one user, so returning an array makes no sense.