### PR TITLE
Save model property values with the forecast

### DIFF
--- a/cql/dev-schema.cql
+++ b/cql/dev-schema.cql
@@ -22,6 +22,12 @@ CREATE TABLE witan.forecast_names (
     AND read_repair_chance = 0.0
     AND speculative_retry = '99.0PERCENTILE';
 
+CREATE TYPE witan.model_property_value (
+    name text,
+    type text,
+    value text
+);
+
 CREATE TABLE witan.forecast_headers (
     forecast_id uuid PRIMARY KEY,
     created timestamp,
@@ -30,21 +36,10 @@ CREATE TABLE witan.forecast_headers (
     description text,
     in_progress boolean,
     name text,
-    owner uuid
-) WITH bloom_filter_fp_chance = 0.01
-    AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
-    AND comment = ''
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
-    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
-    AND dclocal_read_repair_chance = 0.1
-    AND default_time_to_live = 0
-    AND gc_grace_seconds = 864000
-    AND max_index_interval = 2048
-    AND memtable_flush_period_in_ms = 0
-    AND min_index_interval = 128
-    AND read_repair_chance = 0.0
-    AND speculative_retry = '99.0PERCENTILE';
-
+    owner uuid,
+    model_id uuid,
+    model_property_values map<text,frozen<model_property_value>>
+);
 
 CREATE TABLE witan.users (
     id uuid PRIMARY KEY,

--- a/cql/dev-schema.cql
+++ b/cql/dev-schema.cql
@@ -93,7 +93,8 @@ CREATE TABLE witan.forecasts (
 CREATE TYPE witan.model_property (
       name text,
       type text,
-      context text
+      context text,
+      enum_values list<text>
 );
 
 // model names

--- a/cql/dev-schema.cql
+++ b/cql/dev-schema.cql
@@ -24,7 +24,6 @@ CREATE TABLE witan.forecast_names (
 
 CREATE TYPE witan.model_property_value (
     name text,
-    type text,
     value text
 );
 

--- a/cql/generate-staging-schema.sh
+++ b/cql/generate-staging-schema.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+echo "WARNING: assumption that the actual schema definition only starts on line 6 of cql/dev-schema.cql"
+
+echo "DROP KEYSPACE witan;" > cql/staging-schema.cql
+echo "CREATE KEYSPACE witan WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;" >> cql/staging-schema.cql
+sed -n '6,$p' cql/dev-schema.cql >> cql/staging-schema.cql
+echo "Staging schema generated."

--- a/cql/staging-schema.cql
+++ b/cql/staging-schema.cql
@@ -1,11 +1,49 @@
+DROP KEYSPACE witan;
 CREATE KEYSPACE witan WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;
+CREATE TABLE witan.forecast_names (
+    name text,
+    owner uuid,
+    PRIMARY KEY (name, owner)
+) WITH CLUSTERING ORDER BY (owner ASC)
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
+    AND comment = ''
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99.0PERCENTILE';
+
+CREATE TYPE witan.model_property_value (
+    name text,
+    type text,
+    value text
+);
+
+CREATE TABLE witan.forecast_headers (
+    forecast_id uuid PRIMARY KEY,
+    created timestamp,
+    current_version_id uuid,
+    version int,
+    description text,
+    in_progress boolean,
+    name text,
+    owner uuid,
+    model_id uuid,
+    model_property_values map<text,frozen<model_property_value>>
+);
 
 CREATE TABLE witan.users (
     id uuid PRIMARY KEY,
     first_name text,
     name text,
-    username text,
-    password_hash text
+    password_hash text,
+    username text
 ) WITH bloom_filter_fp_chance = 0.01
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = ''
@@ -21,16 +59,71 @@ CREATE TABLE witan.users (
     AND speculative_retry = '99.0PERCENTILE';
 CREATE INDEX user_username ON witan.users (username);
 
-CREATE TABLE witan.forecast_headers (
-    id uuid PRIMARY KEY,
+
+CREATE TABLE witan.forecasts (
+    forecast_id uuid,
+    version int,
+    created timestamp,
+    description text,
+    in_progress boolean,
     name text,
+    owner uuid,
+    version_id uuid,
+    PRIMARY KEY (forecast_id, version)
+) WITH CLUSTERING ORDER BY (version DESC)
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
+    AND comment = ''
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99.0PERCENTILE';
+
+// --------------------------------------------------------------------------------
+// model properties
+CREATE TYPE witan.model_property (
+      name text,
+      type text,
+      context text,
+      enum_values list<text>
+);
+
+// model names
+CREATE TABLE witan.model_names (
+    name text,
+    model_id uuid,
+    PRIMARY KEY (name, model_id)
+) WITH CLUSTERING ORDER BY (model_id ASC)
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
+    AND comment = ''
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99.0PERCENTILE';
+
+// model headers
+CREATE TABLE witan.models (
+    name text,
+    version_id uuid,
     description text,
     created timestamp,
     owner uuid,
-    series_id uuid,
+    model_id uuid PRIMARY KEY,
     version int,
-    in_progress boolean,
-    descendant_id uuid
+    properties list<frozen<witan.model_property>>
 ) WITH bloom_filter_fp_chance = 0.01
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = ''
@@ -44,7 +137,3 @@ CREATE TABLE witan.forecast_headers (
     AND min_index_interval = 128
     AND read_repair_chance = 0.0
     AND speculative_retry = '99.0PERCENTILE';
-CREATE INDEX forecast_header_name ON witan.forecast_headers (name);
-CREATE INDEX forecast_header_series_id ON witan.forecast_headers (series_id);
-CREATE INDEX forecast_header_owner ON witan.forecast_headers (owner);
-

--- a/project.clj
+++ b/project.clj
@@ -28,6 +28,7 @@
                  [javax.mail/mail                "1.4.7"]
                  [overtone/at-at "1.2.0"]]
   :plugins [[lein-ring "0.8.13"]]
+  :jvm-opts ["-Xmx1024m"]
   :ring {:handler witan.app.handler/app
          :nrepl {:start? true :port 7889}}
   :uberjar-name "witan-app.jar"

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -125,9 +125,7 @@
                             :owner owner
                             :in_progress false}))
 
-(defn is-a-number? [txt]
-  (try (number? (read-string txt))
-       (catch NumberFormatException _ false)))
+
 
 (defn add-to-result-values
   [result name type value]

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -128,8 +128,8 @@
 
 
 (defn add-to-result-values
-  [result name type value]
-  (assoc result :values (assoc (:values result) name (hayt/user-type {:name name :type type :value value}))))
+  [result name value]
+  (assoc result :values (assoc (:values result) name (hayt/user-type {:name name :value value}))))
 
 (defn add-to-result-errors
   [result error]
@@ -137,18 +137,18 @@
 
 (defn check-numeric-value
   [result property]
-  (if (is-a-number? (:value property))
-    (add-to-result-values result (:name property) "number" (:value property))
+  (if (util/is-a-number? (:value property))
+    (add-to-result-values result (:name property) (:value property))
     (add-to-result-errors result (str "Wrong type for " (:name property)))))
 
 (defn add-text-value
   [result property]
-  (add-to-result-values result (:name property) "text" (:value property)))
+  (add-to-result-values result (:name property) (:value property)))
 
 (defn check-dropdown-value
   [result property type]
   (if (some #(= (:value property) %) (:enum_values type))
-    (add-to-result-values result (:name property) "dropdown" (:value property))
+    (add-to-result-values result (:name property) (:value property))
     (add-to-result-errors result (str (:value property) " is not an accepted dropdown value"))))
 
 (defn check-property-value

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -33,7 +33,7 @@
                            :created (util/java-Date-to-ISO-Date-Time created)
                            :version-id current_version_id
                            :model-id model_id
-                           :model-property-values (map coerce-value model_property_values)))]
+                           :model-property-values model_property_values))]
     (apply dissoc cleaned (for [[k v] cleaned :when (nil? v)] k))))
 
 (defn- ->Forecast

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -130,11 +130,11 @@
 
 (defn add-to-result-values
   [result name value]
-  (assoc result :values (assoc (:values result) name (hayt/user-type {:name name :value value}))))
+  (update result :values assoc name (hayt/user-type {:name name :value value})))
 
 (defn add-to-result-errors
   [result error]
-  (assoc result :errors (conj (:errors result) error)))
+  (update result :errors conj error))
 
 (defn check-numeric-value
   [result property]

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -141,14 +141,18 @@
   [result property]
   (if (is-a-number? (:value property))
     (add-to-result-values result (:name property) "number" (:value property))
-    (add-to-result-errors result (str "Wrong type for" (:name property)))))
+    (add-to-result-errors result (str "Wrong type for " (:name property)))))
+
+(defn add-text-value
+  [result property]
+  (add-to-result-values result (:name property) "text" (:value property)))
 
 (defn check-property-value [model-property-types result property]
   (let [corresponding-type (some (fn [type] (when (= (:name property) (:name type))
                                              type)) model-property-types)]
     (case (:type corresponding-type)
       "number" (check-numeric-value result property)
-      "text" result
+      "text" (add-text-value result property) ;; no validation needed
       "enum" result
       (add-to-result-errors result "Unknown type")))
   )

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -87,13 +87,14 @@
        first))
 
 (defn create-new-forecast
-  [{:keys [name description owner forecast-id version-id]}]
+  [{:keys [name description owner forecast-id version-id model-id]}]
   (hayt/insert :forecast_headers (hayt/values :name name
                                               :description description
                                               :owner owner
                                               :forecast_id forecast-id
                                               :current_version_id version-id
                                               :in_progress false
+                                              :model_id model-id
                                               :version 0)))
 
 
@@ -128,9 +129,11 @@
   "takes an array of maps with names and values
    finds corresponding model attributes
    validates values as having appropriate types
-   transforms into correct structure [{:name x, :value value-to-text, :type actual-type}]"
+   transforms
+      from query provided data [{:name x :value x}]
+      into correct structure [{:name x :value value-to-text :type actual-type}]"
   [model-id property-values]
-  (let [model (model/find-model-by-model-id model-id)
+  (let [model (model/get-model-by-model-id model-id)
         model-properties (:properties model)]
     (println model-properties))
   )

--- a/src/witan/app/model.clj
+++ b/src/witan/app/model.clj
@@ -51,13 +51,17 @@
                         :version version
                         :properties (map (fn [p] (hayt/user-type p)) properties))))
 
+(defn get-model-by-model-id
+  [model-id]
+  (first (c/exec (find-model-by-model-id model-id))))
+
 (defn add-model!
   [{:keys [name] :as model}]
   (when (empty? (c/exec (find-model-by-name name)))
     (let [model-id (uuid/random)]
-      (c/exec (create-model (assoc model :model_id model-id)))
+      (c/exec (create-model (assoc model :model-id model-id)))
       (c/exec (create-model-name name model-id))
-      (first (c/exec (find-model-by-model-id model-id))))))
+      (get-model-by-model-id model-id))))
 
 (defn get-models
   []

--- a/src/witan/app/schema.clj
+++ b/src/witan/app/schema.clj
@@ -52,7 +52,8 @@
   "Properties that a model can expose"
   {(s/required-key :name)    s/Str
    (s/required-key :type)    ModelPropertyType
-   (s/optional-key :context) s/Any}) ;; varies depending on the type
+   (s/optional-key :context) s/Any
+   (s/optional-key :enum_values) [s/Str]}) ;; varies depending on the type
 
 (def ModelPropertyValue
   "A model property and value binding"

--- a/src/witan/app/schema.clj
+++ b/src/witan/app/schema.clj
@@ -119,11 +119,11 @@
   {(s/required-key :name)             s/Str
    (s/required-key :model-id)         (s/either IdType s/Str)
    (s/optional-key :description)      s/Str
-   (s/optional-key :model-properties) [ModelPropertyValue]})
+   (s/optional-key :model-properties) [{s/Keyword s/Str}]})
 
 (def Forecast
   "Forecast"
-  {(s/required-key :version-id)            IdType
+  {(s/required-key :version-id)    IdType
    (s/required-key :name)          s/Str
    (s/required-key :owner)         IdType
    (s/required-key :forecast-id)     IdType
@@ -131,7 +131,9 @@
    (s/required-key :created)       DateTimeType
    (s/required-key :in-progress?)  s/Bool
    (s/optional-key :description)   s/Str
-   (s/optional-key :tag)           Tag})
+   (s/optional-key :tag)           Tag
+   (s/optional-key :model-id)      IdType
+   (s/optional-key :model-property-values) s/Any})
 
 (def ForecastInfo
   "Forecast in-depth"

--- a/src/witan/app/test_data.clj
+++ b/src/witan/app/test_data.clj
@@ -19,11 +19,10 @@
         ;; versions of these models
         ;;m1_2 (model/update-model! {:model-id (:model_id m1) :owner (:id user1)})
 
-
         ;; add a few forecasts
         f1 (forecast/add-forecast! {:name "My Forecast 1" :description "Description of my forecast" :owner (:id user1) :model-id (:model_id m1)})
         f2 (forecast/add-forecast! {:name "My Forecast 2" :description "Description of my forecast" :owner (:id user2) :model-id (:model_id m1)})
-        f3 (forecast/add-forecast! {:name "My Forecast 3" :description "Description of my forecast" :owner (:id user1) :model-id (:model_id m1)})
+        f3 (forecast/add-forecast! {:name "My Forecast 3" :description "Description of my forecast" :owner (:id user1) :model-id (:model_id m2) :model-properties [{:name "Some field" :value "ole"}]})
 
         ;; versions of these forecasts
         f1_1 (forecast/update-forecast! {:forecast-id (:forecast_id f1) :owner (:id user1)})

--- a/src/witan/app/test_data.clj
+++ b/src/witan/app/test_data.clj
@@ -15,6 +15,8 @@
         m1 (model/add-model! {:name "My Model 1" :description "Description of my model" :owner (:id user1)})
         m2 (model/add-model! {:name "My Model 2" :description "Description of my model" :owner (:id user2)
                               :properties [{:name "Some field" :type "text" :context "Placeholder value 123"}]})
+        m3 (model/add-model! {:name "My Model 3" :description "Model with enum" :owner (:id user2)
+                              :properties [{:name "Boroughs" :type "dropdown" :context "Choose a borough" :enum_values ["Camden" "Richmond Upon Thames" "Hackney" "Barnet"]}]})
 
         ;; versions of these models
         ;;m1_2 (model/update-model! {:model-id (:model_id m1) :owner (:id user1)})

--- a/src/witan/app/test_data.clj
+++ b/src/witan/app/test_data.clj
@@ -21,9 +21,9 @@
 
 
         ;; add a few forecasts
-        f1 (forecast/add-forecast! {:name "My Forecast 1" :description "Description of my forecast" :owner (:id user1)})
-        f2 (forecast/add-forecast! {:name "My Forecast 2" :description "Description of my forecast" :owner (:id user2)})
-        f3 (forecast/add-forecast! {:name "My Forecast 3" :description "Description of my forecast" :owner (:id user1)})
+        f1 (forecast/add-forecast! {:name "My Forecast 1" :description "Description of my forecast" :owner (:id user1) :model-id (:model_id m1)})
+        f2 (forecast/add-forecast! {:name "My Forecast 2" :description "Description of my forecast" :owner (:id user2) :model-id (:model_id m1)})
+        f3 (forecast/add-forecast! {:name "My Forecast 3" :description "Description of my forecast" :owner (:id user1) :model-id (:model_id m1)})
 
         ;; versions of these forecasts
         f1_1 (forecast/update-forecast! {:forecast-id (:forecast_id f1) :owner (:id user1)})

--- a/src/witan/app/util.clj
+++ b/src/witan/app/util.clj
@@ -35,6 +35,10 @@
                params)))
       true)))
 
+(defn is-a-number? [txt]
+  (try (number? (read-string txt))
+       (catch NumberFormatException _ false)))
+
 (defn to-uuid
   [id]
   (if (string? id)

--- a/src/witan/app/util.clj
+++ b/src/witan/app/util.clj
@@ -3,7 +3,8 @@
             [clj-time.core     :as t]
             [clj-time.format   :as tf]
             [clj-time.coerce   :as tc]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [clojure.tools.logging :as log]))
 
 (defn java-Date-to-ISO-Date-Time
   "Converts a java.util.Date to an schema-contrib/ISO-Date-Time"
@@ -34,6 +35,11 @@
                params)))
       true)))
 
+(defn to-uuid
+  [id]
+  (if (string? id)
+    (java.util.UUID/fromString id)
+    id))
 ;;;;;;;;;;;;;;;;
 
 (defn load-extensions!

--- a/src/witan/app/util.clj
+++ b/src/witan/app/util.clj
@@ -3,8 +3,7 @@
             [clj-time.core     :as t]
             [clj-time.format   :as tf]
             [clj-time.coerce   :as tc]
-            [schema.core :as s]
-            [clojure.tools.logging :as log]))
+            [schema.core :as s]))
 
 (defn java-Date-to-ISO-Date-Time
   "Converts a java.util.Date to an schema-contrib/ISO-Date-Time"

--- a/src/witan/app/util.clj
+++ b/src/witan/app/util.clj
@@ -35,14 +35,13 @@
       true)))
 
 (defn is-a-number? [txt]
-  (try (number? (read-string txt))
+  (try (Double/valueOf txt)
        (catch NumberFormatException _ false)))
 
-(defn to-uuid
-  [id]
-  (if (string? id)
-    (java.util.UUID/fromString id)
-    id))
+(defmulti to-uuid type)
+(defmethod to-uuid java.lang.String [id] (java.util.UUID/fromString id))
+(defmethod to-uuid :default [id] id)
+
 ;;;;;;;;;;;;;;;;
 
 (defn load-extensions!

--- a/test/witan/app/forecast_test.clj
+++ b/test/witan/app/forecast_test.clj
@@ -21,8 +21,11 @@
     (with-redefs [model/get-model-by-model-id (fn [_]
                                                 {:properties [{:name "text field" :type "text" :context "this is a text field"}]})]
       (let [checked-property-values (check-property-values "fake-model-id" [{:name "text field" :value "wonderful world"}])]
-
         (is (= (:values checked-property-values) {"text field" (hayt/user-type {:name "text field" :value "wonderful world" :type "text"})})))))
-  (testing "number property")
-  (testing "several properties")
-  (testing "no properties"))
+  (testing "dropdown property"
+    (with-redefs [model/get-model-by-model-id (fn [_]
+                                                {:properties [{:name "Boroughs" :type "dropdown" :context "this is a dropdown field" :enum_values ["Barnet" "Camden" "Southwark"]}]})]
+      (testing "allowed dropdown value"
+        (let [checked-property-values (check-property-values "fake-model-id" [{:name "Boroughs" :value "Camden"}])]
+          (is (= (:values checked-property-values) {"Boroughs" (hayt/user-type {:name "Boroughs" :value "Camden" :type "dropdown"})}))
+          (is (empty? (:errors checked-property-values))))))))

--- a/test/witan/app/forecast_test.clj
+++ b/test/witan/app/forecast_test.clj
@@ -1,0 +1,18 @@
+(ns witan.app.forecast-test
+  (:require [witan.app.forecast :refer :all]
+            [witan.app.model :as model]
+            [clojure.test :refer :all]
+            [qbits.hayt :as hayt]))
+
+
+(deftest test-property-values-handling
+  (testing "numerical property"
+    (with-redefs [model/get-model-by-model-id (fn [id]
+                                                {:properties [{:name "number field" :type "number" :context "this is a number field"}]})]
+      (testing "valid numerical property"
+        (let [checked-property-values (check-property-values "fake-model-id" [{:name "number field" :value "123"}])
+              _ (println "res" checked-property-values)]
+          (is (= (:values checked-property-values) {"number field" (hayt/user-type {:name "number field":value "123" :type "number"})}))))))
+  (testing "text property")
+  (testing "number property")
+  (testing "several properties"))

--- a/test/witan/app/forecast_test.clj
+++ b/test/witan/app/forecast_test.clj
@@ -7,12 +7,22 @@
 
 (deftest test-property-values-handling
   (testing "numerical property"
-    (with-redefs [model/get-model-by-model-id (fn [id]
+    (with-redefs [model/get-model-by-model-id (fn [_]
                                                 {:properties [{:name "number field" :type "number" :context "this is a number field"}]})]
       (testing "valid numerical property"
-        (let [checked-property-values (check-property-values "fake-model-id" [{:name "number field" :value "123"}])
-              _ (println "res" checked-property-values)]
-          (is (= (:values checked-property-values) {"number field" (hayt/user-type {:name "number field":value "123" :type "number"})}))))))
-  (testing "text property")
+        (let [checked-property-values (check-property-values "fake-model-id" [{:name "number field" :value "123"}])]
+          (is (= (:values checked-property-values) {"number field" (hayt/user-type {:name "number field":value "123" :type "number"})}))
+          (is (empty? (:errors checked-property-values)))))
+      (testing "invalid numerical property"
+        (let [checked-property-values (check-property-values "fake-model-id" [{:name "number field" :value "boo123"}])]
+          (is (= (:errors checked-property-values) ["Wrong type for number field"]))
+          (is (empty? (:values checked-property-values)))))))
+  (testing "text property"
+    (with-redefs [model/get-model-by-model-id (fn [_]
+                                                {:properties [{:name "text field" :type "text" :context "this is a text field"}]})]
+      (let [checked-property-values (check-property-values "fake-model-id" [{:name "text field" :value "wonderful world"}])]
+
+        (is (= (:values checked-property-values) {"text field" (hayt/user-type {:name "text field" :value "wonderful world" :type "text"})})))))
   (testing "number property")
-  (testing "several properties"))
+  (testing "several properties")
+  (testing "no properties"))

--- a/test/witan/app/forecast_test.clj
+++ b/test/witan/app/forecast_test.clj
@@ -11,7 +11,7 @@
                                                 {:properties [{:name "number field" :type "number" :context "this is a number field"}]})]
       (testing "valid numerical property"
         (let [checked-property-values (check-property-values "fake-model-id" [{:name "number field" :value "123"}])]
-          (is (= (:values checked-property-values) {"number field" (hayt/user-type {:name "number field":value "123" :type "number"})}))
+          (is (= (:values checked-property-values) {"number field" (hayt/user-type {:name "number field":value "123"})}))
           (is (empty? (:errors checked-property-values)))))
       (testing "invalid numerical property"
         (let [checked-property-values (check-property-values "fake-model-id" [{:name "number field" :value "boo123"}])]
@@ -21,11 +21,11 @@
     (with-redefs [model/get-model-by-model-id (fn [_]
                                                 {:properties [{:name "text field" :type "text" :context "this is a text field"}]})]
       (let [checked-property-values (check-property-values "fake-model-id" [{:name "text field" :value "wonderful world"}])]
-        (is (= (:values checked-property-values) {"text field" (hayt/user-type {:name "text field" :value "wonderful world" :type "text"})})))))
+        (is (= (:values checked-property-values) {"text field" (hayt/user-type {:name "text field" :value "wonderful world"})})))))
   (testing "dropdown property"
     (with-redefs [model/get-model-by-model-id (fn [_]
                                                 {:properties [{:name "Boroughs" :type "dropdown" :context "this is a dropdown field" :enum_values ["Barnet" "Camden" "Southwark"]}]})]
       (testing "allowed dropdown value"
         (let [checked-property-values (check-property-values "fake-model-id" [{:name "Boroughs" :value "Camden"}])]
-          (is (= (:values checked-property-values) {"Boroughs" (hayt/user-type {:name "Boroughs" :value "Camden" :type "dropdown"})}))
+          (is (= (:values checked-property-values) {"Boroughs" (hayt/user-type {:name "Boroughs" :value "Camden"})}))
           (is (empty? (:errors checked-property-values))))))))


### PR DESCRIPTION
In this first approach, model properties can have 3 formats: text, number and dropdown.
When they are posted, they have to be checked for validity, and saved away with the forecast.
(first concrete example of this will be the London borough)