### PR TITLE
add model id and properties to forecast versions

### DIFF
--- a/cql/dev-schema.cql
+++ b/cql/dev-schema.cql
@@ -73,6 +73,8 @@ CREATE TABLE witan.forecasts (
     owner uuid,
     owner_name text,
     version_id uuid,
+    model_id uuid,
+    model_property_values map<text,frozen<model_property_value>>,
     PRIMARY KEY (forecast_id, version)
 ) WITH CLUSTERING ORDER BY (version DESC)
     AND bloom_filter_fp_chance = 0.01

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -252,7 +252,7 @@
                               :owner-name owner-name
                               :in-progress true
                               :forecast-id forecast-id
-                              :model-id (:model-id corresponding-forecast-header))]
+                              :model-id (:model_id corresponding-forecast-header))]
       (c/exec (create-forecast-version new-forecast))
       (c/exec (update-forecast-current-version-id forecast-id new-version-id new-version))
       (c/exec (find-forecast-by-version forecast-id new-version)))))

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -113,7 +113,11 @@
                                             :owner owner)))
 
 (defn create-forecast-version
+<<<<<<< HEAD
   [{:keys [name description owner owner-name forecast-id version in_progress id version-id]}]
+=======
+  [{:keys [name description owner forecast-id version in_progress id version-id model-id model-property-values]}]
+>>>>>>> model id and model properties in versions
   (let [creation-time (tf/unparse (tf/formatters :date-time) (t/now))]
     (hayt/insert :forecasts (hayt/values
                              :forecast_id forecast-id
@@ -124,9 +128,12 @@
                              :owner_name owner-name
                              :version_id version-id
                              :version version
-                             :in_progress in_progress))))
+                             :in_progress in_progress
+                             :model_id model-id
+                             :model_property_values model-property-values))))
+
 (defn create-first-version
-  [{:keys [forecast-id version-id name description owner owner-name]}]
+  [{:keys [forecast-id version-id name description owner owner-name model-id model-property-values]}]
   (create-forecast-version {:name name
                             :description description
                             :forecast-id forecast-id
@@ -134,9 +141,9 @@
                             :version 0
                             :owner owner
                             :owner_name owner-name
-                            :in_progress false}))
-
-
+                            :in_progress false
+                            :model-id model-id
+                            :model-property-values model-property-values}))
 
 (defn add-to-result-values
   [result name value]
@@ -213,13 +220,15 @@
     (let [new-version (inc (:version latest-forecast))
           new-version-id (uuid/random)
           owner-name (-> owner user/retrieve-user :name)
+          corresponding-forecast-header (first (c/exec (find-forecast-by-id forecast-id)))
           new-forecast (assoc latest-forecast
                               :version new-version
                               :version-id new-version-id
                               :owner owner
                               :owner-name owner-name
                               :in-progress true
-                              :forecast-id forecast-id)]
+                              :forecast-id forecast-id
+                              :model-id (:model-id corresponding-forecast-header))]
       (c/exec (create-forecast-version new-forecast))
       (c/exec (update-forecast-current-version-id forecast-id new-version-id new-version))
       (c/exec (find-forecast-by-version forecast-id new-version)))))

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -164,7 +164,7 @@
                             :version-id version-id
                             :version 0
                             :owner owner
-                            :owner_name owner-name
+                            :owner-name owner-name
                             :in_progress false
                             :model-id model-id
                             :model-property-values model-property-values}))

--- a/src/witan/app/schema.clj
+++ b/src/witan/app/schema.clj
@@ -58,7 +58,7 @@
 (def ModelPropertyValue
   "A model property and value binding"
   {(s/required-key :name)  s/Str
-   (s/required-key :value) s/Any}) ;; varies depending on the ModelProperty type
+   (s/required-key :value) (s/either s/Str s/Int)}) ;; varies depending on the ModelProperty type
 
 (def DataItem
   "A data item"
@@ -141,7 +141,7 @@
    (s/optional-key :description)   s/Str
    (s/optional-key :tag)           Tag
    (s/optional-key :model-id)      IdType
-   (s/optional-key :model-property-values) s/Any})
+   (s/optional-key :model-property-values) [ModelPropertyValue]})
 
 (def ForecastInfo
   "Forecast in-depth"

--- a/src/witan/app/schema.clj
+++ b/src/witan/app/schema.clj
@@ -70,6 +70,14 @@
    (s/optional-key :s3-url)    s/Str
    (s/required-key :created)   DateTimeType})
 
+(def ModelInputCategory
+  "Inputs into the model"
+  s/Str)
+
+(def ModelOutputCategory
+  "Outputs from the model"
+  s/Str)
+
 (def Model
   "Models are the center-piece of a Forecast"
   {(s/required-key :model-id)    IdType
@@ -80,34 +88,20 @@
    (s/required-key :created)     DateTimeType
    (s/optional-key :description) s/Str
    (s/optional-key :properties)  [ModelProperty]
-   (s/optional-key :input-data) [{(s/optional-key :category) s/Str
+   (s/optional-key :input-data) [{(s/required-key :category) ModelInputCategory
                                   (s/optional-key :default) DataItem}]
-   (s/optional-key :output-data) [{(s/optional-key :category) s/Str}]})
-
-(def DataItemEntry
-  "Used to isolate a data item ID"
-  {(s/required-key :data-item) DataItem})
-
-(def ModelInputCategory
-  "Inputs into the model"
-  {(s/required-key :id)   IdType
-   (s/required-key :name) s/Str})
-
-(def ModelOutputCategory
-  "Outputs from the model"
-  {(s/required-key :id)   IdType
-   (s/required-key :name) s/Str})
+   (s/optional-key :output-data) [{(s/required-key :category) ModelOutputCategory}]})
 
 (def ModelInput
   "An input category with a data item"
-  {ModelInputCategory (s/maybe DataItemEntry)})
+  {ModelInputCategory DataItem})
 
 (def ModelOutput
   "An output category with a data item"
-  {ModelOutputCategory (s/maybe (s/cond-pre [DataItemEntry] DataItemEntry))})
+  {ModelOutputCategory [DataItem]})
 
 (def ModelInfo
-  "More in-depth information about a Model"
+  "Forecast data in the context of the model"
   {(s/required-key :model)      Model
    (s/required-key :inputs)     [ModelInput]
    (s/required-key :outputs)    [ModelOutput]
@@ -140,8 +134,7 @@
    (s/required-key :in-progress?)  s/Bool
    (s/optional-key :description)   s/Str
    (s/optional-key :tag)           Tag
-   (s/optional-key :model-id)      IdType
-   (s/optional-key :model-property-values) [ModelPropertyValue]})
+   (s/optional-key :model-id)      IdType})
 
 (def ForecastInfo
   "Forecast in-depth"

--- a/src/witan/app/schema.clj
+++ b/src/witan/app/schema.clj
@@ -137,9 +137,9 @@
    (s/optional-key :model-id)      IdType})
 
 (def ForecastInfo
-  "Forecast in-depth"
-  {(s/required-key :forecast) Forecast
-   (s/required-key :model)    ModelInfo})
+  "Forecast in-depth
+   TODO: should be (merge Forecast ModelInfo"
+  Forecast)
 
 (def ShareRequest
   "A request to adjust sharing rules for a tag"


### PR DESCRIPTION
Two things here:
- fixed schema for property values
- added model id and properties to forecast versions
= Groundwork for the next feature to have full model information in the single version API