### PR TITLE
Schema changes to ForecastInfo to pass model props + /models/:id

### DIFF
--- a/cql/staging-schema.cql
+++ b/cql/staging-schema.cql
@@ -21,7 +21,6 @@ CREATE TABLE witan.forecast_names (
 
 CREATE TYPE witan.model_property_value (
     name text,
-    type text,
     value text
 );
 
@@ -34,6 +33,7 @@ CREATE TABLE witan.forecast_headers (
     in_progress boolean,
     name text,
     owner uuid,
+    owner_name text,
     model_id uuid,
     model_property_values map<text,frozen<model_property_value>>
 );
@@ -68,7 +68,10 @@ CREATE TABLE witan.forecasts (
     in_progress boolean,
     name text,
     owner uuid,
+    owner_name text,
     version_id uuid,
+    model_id uuid,
+    model_property_values map<text,frozen<model_property_value>>,
     PRIMARY KEY (forecast_id, version)
 ) WITH CLUSTERING ORDER BY (version DESC)
     AND bloom_filter_fp_chance = 0.01
@@ -115,6 +118,36 @@ CREATE TABLE witan.model_names (
     AND speculative_retry = '99.0PERCENTILE';
 
 // model headers
+CREATE TABLE witan.data_by_data_id (
+  data_id uuid PRIMARY KEY,
+  category text,
+  name text,
+  publisher uuid,
+  version int,
+  s3_url text,
+  created timestamp
+);
+
+CREATE TABLE witan.data_by_category (
+  data_id uuid,
+  category text PRIMARY KEY,
+  name text,
+  publisher uuid,
+  version int,
+  s3_url text,
+  created timestamp
+);
+
+CREATE TYPE witan.model_data (
+  data_id uuid,
+  category text,
+  name text,
+  publisher uuid,
+  version int,
+  s3_url text,
+  created timestamp
+);
+
 CREATE TABLE witan.models (
     name text,
     version_id uuid,
@@ -123,7 +156,10 @@ CREATE TABLE witan.models (
     owner uuid,
     model_id uuid PRIMARY KEY,
     version int,
-    properties list<frozen<witan.model_property>>
+    properties list<frozen<witan.model_property>>,
+    input_data list<text>,
+    input_data_defaults map<text,frozen<model_data>>,
+    output_data list<text>
 ) WITH bloom_filter_fp_chance = 0.01
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = ''
@@ -137,3 +173,5 @@ CREATE TABLE witan.models (
     AND min_index_interval = 128
     AND read_repair_chance = 0.0
     AND speculative_retry = '99.0PERCENTILE';
+
+// Data items

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -260,11 +260,10 @@
 
 (defn get-forecast
   [{:keys [id version latest-version?]}]
-  (if version
-    (c/exec (find-forecast-by-version id version))
-    (if latest-version?
-      (get-most-recent-version id)
-      (c/exec (find-forecast-versions-by-id id)))))
+  (cond
+    version         (c/exec (find-forecast-by-version id version))
+    latest-version? (get-most-recent-version id)
+    :else           (c/exec (find-forecast-versions-by-id id))))
 
 ;;;;;;
 

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -267,8 +267,12 @@
 (defn get-forecast
   [{:keys [id version latest-version?]}]
   (cond
-    version         (vector (get-forecast-by-version id version))
-    latest-version? (vector (get-most-recent-version id))
+    version         (if-let [forecast (get-forecast-by-version id version)]
+                      [forecast]
+                      [])
+    latest-version? (if-let [forecast (get-most-recent-version id)]
+                      [forecast]
+                      [])
     :else           (c/exec (find-forecast-versions-by-id id))))
 
 ;;;;;;

--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -113,13 +113,10 @@
                                   :version new-version})
                (hayt/where {:forecast_id forecast-id})))
 
-(defn retrieve-forecast-most-recent-of-series
+(defn get-most-recent-version
   "uses the descending ordering of the versions in the forecast table"
   [id]
-  (->> id
-       find-forecast-by-id
-       c/exec
-       first))
+  (c/exec (merge (find-forecast-versions-by-id id) (hayt/limit 1))))
 
 (defn create-new-forecast
   [{:keys [name description owner owner-name forecast-id version-id model-id model-property-values]}]
@@ -240,7 +237,7 @@
 
 (defn update-forecast!
   [{:keys [forecast-id owner]}]
-  (if-let [latest-forecast (retrieve-forecast-most-recent-of-series forecast-id)]
+  (if-let [latest-forecast (get-most-recent-version forecast-id)]
     (let [new-version (inc (:version latest-forecast))
           new-version-id (uuid/random)
           owner-name (-> owner user/retrieve-user :name)
@@ -266,7 +263,7 @@
   (if version
     (c/exec (find-forecast-by-version id version))
     (if latest-version?
-      (c/exec (merge (find-forecast-versions-by-id id) (hayt/limit 1)))
+      (get-most-recent-version id)
       (c/exec (find-forecast-versions-by-id id)))))
 
 ;;;;;;

--- a/src/witan/app/handler.clj
+++ b/src/witan/app/handler.clj
@@ -127,7 +127,8 @@
                                model/models)
                    (sweet/GET* "/models/:id" []
                                :summary "Get model specified by ID"
-                               (not-implemented))
+                               :path-params [id :- java.util.UUID]
+                               (model/model {:id id}))
                    (sweet/GET* "/forecasts" []
                                :summary "Get forecasts available to a user"
                                forecast/forecasts)

--- a/src/witan/app/model.clj
+++ b/src/witan/app/model.clj
@@ -105,3 +105,15 @@
   :handle-ok (fn [_] (s/validate
                       [ws/Model]
                       (map ->Model (get-models)))))
+
+(defresource model [{:keys [id]}]
+  :allowed-methods #{:get}
+  :exists? (fn [ctx]
+             (let [result (get-model-by-model-id id)]
+               [result {:result result}]))
+  :available-media-types ["application/json"]
+  :handle-ok (fn [{:keys [result]}]
+               (s/validate
+                     ws/Model
+                     (->Model result)))
+  )

--- a/src/witan/app/schema.clj
+++ b/src/witan/app/schema.clj
@@ -102,10 +102,9 @@
 
 (def ModelInfo
   "Forecast data in the context of the model"
-  {(s/required-key :model)      Model
-   (s/required-key :inputs)     [ModelInput]
+  {(s/required-key :inputs)     [ModelInput]
    (s/required-key :outputs)    [ModelOutput]
-   (s/optional-key :properties) [ModelPropertyValue]})
+   (s/optional-key :property-values) [ModelPropertyValue]})
 
 (def Tag
   "A tag is an annotated symlink to a forecast id and version"
@@ -141,7 +140,7 @@
    TODO: should be (merge Forecast ModelInfo"
   (merge
    Forecast
-   {(s/optional-key :model-property-values) [ModelPropertyValue]}))
+   ModelInfo))
 
 (def ShareRequest
   "A request to adjust sharing rules for a tag"

--- a/test/witan/app/handler_test.clj
+++ b/test/witan/app/handler_test.clj
@@ -90,6 +90,9 @@
      :version 0,
      :version_id #uuid "653c149a-86d8-4a3f-a7a8-d898c070177e"}))
 
+(defn get-dummy-model []
+  {:description "Description of my model", :properties [{:name "Some field", :type "text", :context "Placeholder value 123", :enum_values []}], :version_id #uuid "fa200d2d-816d-4502-b94a-9ba020f2f1f4", :input_data ["Base population data"], :name "My Model 2", :output_data ["All the population data"], :input_data_defaults {}, :created #inst "2015-10-21T10:51:22.093-00:00", :model_id #uuid "dbd5d07e-ec05-4409-83da-71971897cfa0", :version 1, :owner #uuid "98f9adcb-bc80-407c-b9c8-736506f6e410"})
+
 (defn auth-header [token] {"Authorization" (str "Token " token)})
 
 (defn logged-in-user-token []
@@ -167,7 +170,7 @@
           (is (seq? body)))))
 
     (testing "get forecast specific version"
-      (with-redefs [witan.app.config/exec (fn [_] [(second (get-dummy-forecasts))])] ;; db would find correct version
+      (with-redefs [witan.app.forecast/get-forecast-by-version (fn [_ _] (second (get-dummy-forecasts)))]
         (let [token (logged-in-user-token)
               [status body _] (get* app "/api/forecasts/fd44474d-e0f8-4713-bacf-299e503e4f30/1" {} (auth-header token))]
           (is (= status 200))
@@ -176,7 +179,7 @@
           (is (= (:version-id body) "f960e442-2c85-489e-9807-4eeecd6fd55a")))))
 
     (testing "get forecast latest version"
-      (with-redefs [witan.app.forecast/get-most-recent-version (comp first get-dummy-forecasts)]
+      (with-redefs [witan.app.forecast/get-most-recent-version (fn [_] (first (get-dummy-forecasts)))]
         (let [token (logged-in-user-token)
               [status body _] (get* app "/api/forecasts/fd44474d-e0f8-4713-bacf-299e503e4f30/latest" {} (auth-header token))]
           (is (= status 200))

--- a/test/witan/app/handler_test.clj
+++ b/test/witan/app/handler_test.clj
@@ -48,7 +48,9 @@
      :name "My Forecast 1",
      :owner #uuid "d8fc0f3c-0535-4959-bf9e-505af9a59ad9",
      :owner_name "User 3",
-     :version_id #uuid "78b1bf97-0ebe-42ef-8031-384e504cf795"}
+     :version_id #uuid "78b1bf97-0ebe-42ef-8031-384e504cf795"
+     :model_id #uuid "dbd5d07e-ec05-4409-83da-71971897cfa0"
+     :model_property_values {}}
     {:forecast_id #uuid "fd44474d-e0f8-4713-bacf-299e503e4f30",
      :version 1,
      :created #inst "2015-10-14T08:41:21.253-00:00",
@@ -57,7 +59,8 @@
      :name "My Forecast 1",
      :owner #uuid "d8fc0f3c-0535-4959-bf9e-505af9a59ad9",
      :owner_name "User 3",
-     :version_id #uuid "f960e442-2c85-489e-9807-4eeecd6fd55a"}
+     :version_id #uuid "f960e442-2c85-489e-9807-4eeecd6fd55a"
+     :model_id #uuid "dbd5d07e-ec05-4409-83da-71971897cfa0"}
     {:description "Description of my forecast",
      :name "My Forecast 1",
      :created #inst "2015-10-06T12:44:17.176-00:00",
@@ -66,7 +69,8 @@
      :forecast_id #uuid "fd44474d-e0f8-4713-bacf-299e503e4f30",
      :version 0,
      :owner #uuid "cac4ba3a-07c8-4e79-9ae0-d97317bb0d45",
-     :owner_name "User 1"}))
+     :owner_name "User 1"
+     :model_id #uuid "dbd5d07e-ec05-4409-83da-71971897cfa0"}))
 
 (defn get-dummy-models []
   '({:name "My Model 2",
@@ -172,7 +176,7 @@
           (is (= (:version-id body) "f960e442-2c85-489e-9807-4eeecd6fd55a")))))
 
     (testing "get forecast latest version"
-      (with-redefs [witan.app.config/exec get-dummy-forecasts]
+      (with-redefs [witan.app.forecast/get-most-recent-version (comp first get-dummy-forecasts)]
         (let [token (logged-in-user-token)
               [status body _] (get* app "/api/forecasts/fd44474d-e0f8-4713-bacf-299e503e4f30/latest" {} (auth-header token))]
           (is (= status 200))


### PR DESCRIPTION
- Added model properties to the > 0 versions
- refactored a little bit
- service for /models/:id to retrieve model info

The input and output in the Forecast are stubbed to [] at the moment.