### PR TITLE
Delete 'version zero' when creating a version one

### DIFF
--- a/src/witan/app/forecast.clj
+++ b/src/witan/app/forecast.clj
@@ -247,7 +247,7 @@
 
 (defn update-forecast!
   [{:keys [forecast-id owner]}]
-  (if-let [latest-forecast (retrieve-forecast-most-recent-of-series forecast-id)]
+  (if-let [latest-forecast (get-most-recent-version forecast-id)]
     (let [old-version (:version latest-forecast)
           new-version (inc old-version)
           new-version-id (uuid/random)


### PR DESCRIPTION
Version 0 is uninteresting to us because it's a forecast that hasn't
been run. It's a limbo state for forecasts that require inputs and
therefore, once version one has been run, it should be deleted.