### PR TITLE
get signature for data upload

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,9 @@
                  [org.slf4j/jcl-over-slf4j       ~slf4j-version]
                  [org.slf4j/log4j-over-slf4j     ~slf4j-version]
                  [javax.mail/mail                "1.4.7"]
-                 [overtone/at-at "1.2.0"]]
+                 [overtone/at-at "1.2.0"]
+                 [org.martinklepsch/s3-beam "0.3.1"]
+                 [environ "1.0.1"]]
   :plugins [[lein-ring "0.8.13"]]
   :jvm-opts ["-Xmx1024m"]
   :ring {:handler witan.app.handler/app

--- a/resources/dev.witan-app.edn
+++ b/resources/dev.witan-app.edn
@@ -1,2 +1,3 @@
 {:cassandra-session {:host "localhost"
-                     :keyspace "witan"}}
+                     :keyspace "witan"}
+ :s3 {:bucket "witan-test-data"}}

--- a/resources/staging.witan-app.edn
+++ b/resources/staging.witan-app.edn
@@ -1,2 +1,3 @@
 {:cassandra-session {:host "cassandra-dcos-node.cassandra.dcos.mesos"
-                     :keyspace "witan"}}
+                     :keyspace "witan"}
+ :s3 {:bucket "witan-staging-data"}}

--- a/src/witan/app/handler.clj
+++ b/src/witan/app/handler.clj
@@ -14,6 +14,7 @@
             [witan.app.forecast :as forecast]
             [witan.app.model :as model]
             [witan.app.util :refer [load-extensions!]]
+            [witan.app.s3 :as s3]
             [schema.core :as s]
             [witan.app.schema :as w]
             [compojure.api.sweet :as sweet]
@@ -160,9 +161,9 @@
                    (sweet/POST* "/share-request/:tag-id" []
                                 :summary "Creates a request to update the sharing properties of a tag"
                                 (not-implemented))
-                   (sweet/POST* "/data/upload" []
-                                :summary "Upload endpoint for data items"
-                                (not-implemented))
+                   (sweet/GET* "/data/sign" []
+                                :summary "Provide amazon presigned url for upload of data items"
+                                (s3/sign))
                    (sweet/GET* "/data" []
                                :summary "Expects a query string. Allows searching of data items"
                                (not-implemented))

--- a/src/witan/app/s3.clj
+++ b/src/witan/app/s3.clj
@@ -1,0 +1,22 @@
+(ns witan.app.s3
+  (:require [s3-beam.handler :as s3b]
+            [witan.app.config :as c]
+            [environ.core :as environ]))
+
+(def bucket
+  (-> c/config :s3 :bucket))
+
+(def aws-zone "eu-central-1")
+
+(def aws-access-key
+  (environ/env :aws-access-key))
+
+(def aws-secret-key
+  (environ/env :aws-secret-key))
+
+(defn sign
+  []
+  (s3b/s3-sign bucket
+               aws-zone
+               aws-access-key
+               aws-secret-key))


### PR DESCRIPTION
getting signature for data upload using s3-beam
requires setting AWS_ACCESS_KEY AWS_SECRET_KEY environment variables, and changing the configuration to contain :s3 {:bucket x}