### PR TITLE
improvement to exists (avoiding connection leaks)

### DIFF
--- a/src/witan/app/s3.clj
+++ b/src/witan/app/s3.clj
@@ -28,5 +28,5 @@
 (defn exists?
   [key]
   (try
-    (amazonica/get-object bucket key)
+    (boolean (amazonica/get-object-metadata bucket key))
     (catch com.amazonaws.services.s3.model.AmazonS3Exception _ false)))


### PR DESCRIPTION
Suggested by Neale, because get-object actually causes an open connection leak (unless you explicitly close it)
see https://github.com/weavejester/clj-aws-s3/commit/d249e174d715ab988b28e3caabfc491248678716