### PR TITLE
Added `:created` to forecast headers.

### DIFF
--- a/src/witan/app/util.clj
+++ b/src/witan/app/util.clj
@@ -8,8 +8,9 @@
 (defn java-Date-to-ISO-Date-Time
   "Converts a java.util.Date to an schema-contrib/ISO-Date-Time"
   [datetime]
-  (tf/unparse (tf/formatters :date-hour-minute-second)
-              (tc/from-date datetime)))
+  (when datetime
+    (tf/unparse (tf/formatters :date-hour-minute-second)
+                (tc/from-date datetime))))
 
 (defn http-post?
   [ctx]


### PR DESCRIPTION
I discovered this bug by changing the conversion fn in utils to return
nil if the provided datetime was nil. Previously, this function would
return `(t/now)` which is erroneous.