### PR TITLE
Change `sed` delimiters to cope with slashes in AWS secrets

### DIFF
--- a/prepare-aws-creds
+++ b/prepare-aws-creds
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sed -e "s/AWS_ACCESS_KEY/$WITAN_APP_AWS_KEY/" -e "s/AWS_SECRET_KEY/$WITAN_APP_AWS_SECRET/" ./resources/aws-credentials.template > ./resources/aws-credentials
+sed -e "s@AWS_ACCESS_KEY@$WITAN_APP_AWS_KEY@" -e "s@AWS_SECRET_KEY@$WITAN_APP_AWS_SECRET@" ./resources/aws-credentials.template > ./resources/aws-credentials

--- a/prepare-aws-creds
+++ b/prepare-aws-creds
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sed -e "s@AWS_ACCESS_KEY@$WITAN_APP_AWS_KEY@" -e "s@AWS_SECRET_KEY@$WITAN_APP_AWS_SECRET@" ./resources/aws-credentials.template > ./resources/aws-credentials
+sed -e "s@AWS_ACCESS_KEY@${WITAN_APP_AWS_KEY}@" -e "s@AWS_SECRET_KEY@${WITAN_APP_AWS_SECRET}@" ./resources/aws-credentials.template > ./resources/aws-credentials


### PR DESCRIPTION
The regex for secrets is `(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=]).` (https://blogs.aws.amazon.com/security/blog/tag/key+rotation) so the belief is that the `@` will work as an appropriate delimiter.