### PR TITLE
Added /data/public endpoint

### DIFF
--- a/src/witan/app/data.clj
+++ b/src/witan/app/data.clj
@@ -169,7 +169,6 @@
   :handle-ok {:location (str (s3/presigned-download-url
                               (str "public/" filename)
                               filename))}
-  :post-to-missing? (fn [_] false)
   :existed? (fn [ctx]
               (s3/exists? (str "public/" filename)))
   :moved-permanently? (fn [_] false)

--- a/src/witan/app/data.clj
+++ b/src/witan/app/data.clj
@@ -159,3 +159,20 @@
                                           :s3-key (:s3-key ctx)
                                           :public? public
                                           :publisher user-id})))))
+
+(defresource public [filename redirect]
+  util/json-resource
+  :allow-methods #{:get}
+  :exists? (fn [_] (if redirect
+                     false
+                     (s3/exists? (str "public/" filename))))
+  :handle-ok {:location (str (s3/presigned-download-url
+                              (str "public/" filename)
+                              filename))}
+  :post-to-missing? (fn [_] false)
+  :existed? (fn [ctx]
+              (s3/exists? (str "public/" filename)))
+  :moved-permanently? (fn [_] false)
+  :moved-temporarily? {:location (s3/presigned-download-url
+                                  (str "public/" filename)
+                                  filename)})

--- a/src/witan/app/demo_data.clj
+++ b/src/witan/app/demo_data.clj
@@ -21,7 +21,7 @@
                                  :description "Dwellings from most recent census"})
 
 (def development-category {:category "development-data"
-                           :description "Net new dwellings from London Development Database and projections of housing (SHLAA or BPO)"})
+                           :description "Net new dwellings from London Development Database and projections of housing (SHLAA or BPO). [Download a template here.](/data/public/Template_DevelopmentData_{{ model-properties.borough }}.csv)"})
 (def output-category {:category "housing-linked-population"
                       :description "Housing-linked population projections"})
 

--- a/src/witan/app/handler.clj
+++ b/src/witan/app/handler.clj
@@ -186,9 +186,11 @@
                                :path-params [category :- String]
                                :query-params [{groups :- [String] []}]
                                (data/search {:category category :groups (set groups)}))
-                   (sweet/GET* "/data/download/:uuid" []
-                               :summary "Downloads the data of a given id"
-                               (not-implemented))))
+                   (sweet/GET* "/data/public/:filename" []
+                               :summary "Downloads the data of a given filename from the public folder"
+                               :path-params [filename :- String]
+                               :query-params [{redirect :- Boolean true}]
+                               (data/public filename redirect))))
 
   (sweet/ANY* "/*" []
               (not-found {:message "These aren't the droids you're looking for."})))

--- a/src/witan/app/test_data.clj
+++ b/src/witan/app/test_data.clj
@@ -21,7 +21,7 @@
                                  :description "Dwellings from most recent census"})
 
 (def development-category {:category "development-data"
-                           :description "Net new dwellings from London Development Database and projections of housing (SHLAA or BPO). [Download a template here.](http://www.google.com)"})
+                           :description "Net new dwellings from London Development Database and projections of housing (SHLAA or BPO). [Download a template here.](/data/public/Template_DevelopmentData_{{ model-properties.borough }}.csv)"})
 (def output-category {:category "housing-linked-population"
                       :description "Housing-linked population projections"})
 


### PR DESCRIPTION
https://github.com/MastodonC/witan.ui/commit/35fea3fb65392bf2a00259f519ed51f17360c1c6

```
Added /data/public endpoint which 307's us to...
...S3 links if they exist in the public directory. This was implemented
to facilitate templates. By default, the endpoint will307 but passing
`redirect=false` as a query param will cause the link to be returned in
a JSON structure.
```