### PR TITLE
Add Kafka boilerplate to witan.app

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -34,10 +34,12 @@
                  [amazonica "0.3.35" :exclusions [com.amazonaws/aws-java-sdk]]
                  [clojure-csv/clojure-csv "2.0.1"]
                  [witan.models "0.1.6"]
+                 [clj-tuple "0.2.2"]
                  [clj-http "2.0.0"]
                  [slugger "1.0.1"]
                  [com.stuartsierra/component "0.3.0"]
                  [markdown-clj "0.9.82"]
+                 [clj-kafka "0.3.4" :exclusions [org.slf4j/slf4j-log4j12]]
 
                  ;; do this here to avoid clashes
                  ;; with local profiles.clj. We need

--- a/resources/dev.witan-app.edn
+++ b/resources/dev.witan-app.edn
@@ -1,4 +1,6 @@
 {:cassandra-session {:host "localhost"
                      :keyspace "witan"
                      :replication 1}
- :s3 {:bucket "witan-test-data"}}
+ :s3 {:bucket "witan-test-data"}
+ :kafka {:host "localhost"
+         :port 2181}}

--- a/run_witan_app.sh
+++ b/run_witan_app.sh
@@ -6,6 +6,8 @@ cat <<EOF  > /root/.witan-app.edn
                      :keyspace "witan"
                      :replication 3}
  :s3 {:bucket "witan-${ENVIRONMENT?not defined}-data"}}
+:kafka {:host "master.mesos"
+         :port 2181}
 EOF
 
 # running jar

--- a/scripts/cqlsh.sh
+++ b/scripts/cqlsh.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# https://hub.docker.com/_/cassandra/
+docker run -it --link some-cassandra:cassandra --rm cassandra:2.2.4 cqlsh cassandra

--- a/scripts/kafka_console_consumer.sh
+++ b/scripts/kafka_console_consumer.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# https://hub.docker.com/r/ches/kafka/
+DEFAULT_TOPIC=command
+DEFAULT_ADDR=localhost
+
+echo -n "Topic to read [${DEFAULT_TOPIC}]: "
+read name
+
+TOPIC=${name:-$DEFAULT_TOPIC}
+
+echo -n "ZooKeeper Address [${DEFAULT_ADDR}]: "
+read addr
+
+ADDR=${addr:-$DEFAULT_ADDR}
+
+docker run --net=host --rm ches/kafka kafka-console-consumer.sh --topic ${TOPIC} --from-beginning --zookeeper ${ADDR}:2181

--- a/scripts/kafka_console_producer.sh
+++ b/scripts/kafka_console_producer.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# https://hub.docker.com/r/ches/kafka/
+DEFAULT_TOPIC=command
+DEFAULT_ADDR=localhost
+
+echo -n "Topic to write to [${DEFAULT_TOPIC}]: "
+read name
+
+TOPIC=${name:-$DEFAULT_TOPIC}
+
+echo -n "Kafka Address [${DEFAULT_ADDR}]: "
+read addr
+
+ADDR=${addr:-$DEFAULT_ADDR}
+
+docker run --net=host --rm --interactive ches/kafka kafka-console-producer.sh --topic ${TOPIC} --broker-list ${ADDR}:9092

--- a/scripts/run_cassandra.sh
+++ b/scripts/run_cassandra.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# https://hub.docker.com/_/cassandra/
+docker rm some-cassandra
+docker run --name some-cassandra -v /usr/local/cassandra:/var/lib/cassandra -d -p 9042:9042 cassandra:2.2.4

--- a/scripts/run_kafka.sh
+++ b/scripts/run_kafka.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# https://hub.docker.com/r/ches/kafka/
+docker rm zookeeper
+docker rm kafka
+docker run -d --name zookeeper -p 2181:2181 jplock/zookeeper:3.4.6
+docker run -d --name kafka --link zookeeper:zookeeper -p 9092:9092 ches/kafka
+echo "Waiting 5s..."
+sleep 5s
+docker run --net=host --rm ches/kafka kafka-topics.sh --create --topic test --replication-factor 1 --partitions 1 --zookeeper localhost
+docker run --net=host --rm ches/kafka kafka-topics.sh --create --topic command --replication-factor 1 --partitions 1 --zookeeper localhost

--- a/src/witan/app/components/kafka.clj
+++ b/src/witan/app/components/kafka.clj
@@ -1,0 +1,40 @@
+(ns witan.app.components.kafka
+  (:require [com.stuartsierra.component :as component]
+            [witan.app.mq               :refer [MQSendMessage]]
+            [clojure.tools.logging      :as log]
+            [clj-kafka.producer         :as kafka]
+            [clj-kafka.zk               :as zk]
+            [clojure.core.async         :as async :refer [go-loop chan <! close! put!]]))
+
+(defrecord KafkaProducer [host port]
+  MQSendMessage
+  (send-message! [component topic message]
+    (if-let [conn (:connection component)]
+      (if-let [error (kafka/send-message conn (kafka/message topic (.getBytes message)))]
+        (log/error "Failed to send message to Kafka:" error)
+        (log/debug "Message was sent to Kafka:" topic message))
+      (log/error "There is no connection to Kafka.")))
+
+  component/Lifecycle
+  (start [component]
+    (log/info "Starting Kafka producer...")
+    (log/info "Building broker list from ZooKeeper:" host port)
+    (let [broker-string (->>
+                         (zk/brokers {"zookeeper.connect" (str host ":" port)})
+                         (map (juxt :host :port))
+                         (map (partial interpose \:))
+                         (map (partial apply str))
+                         (interpose \,)
+                         (apply str))
+          _ (log/debug "Broker list" broker-string)
+          connection (kafka/producer {"metadata.broker.list" broker-string
+                                      "serializer.class" "kafka.serializer.DefaultEncoder"
+                                      "partitioner.class" "kafka.producer.DefaultPartitioner"})]
+      (assoc component :connection connection)))
+
+  (stop [component]
+    (log/info "Stopping Kafka producer..." (:queue component))
+    (assoc component :connection nil)))
+
+(defn new-kafka-producer [host port]
+  (map->KafkaProducer {:host host :port port}))

--- a/src/witan/app/config.clj
+++ b/src/witan/app/config.clj
@@ -34,3 +34,7 @@
   [body]
   (let [conn-fn (or @conn (reset! conn (store-execute config)))]
     (conn-fn body)))
+
+(defn kafka
+  [k]
+  (get (:kafka config) k))

--- a/src/witan/app/mq.clj
+++ b/src/witan/app/mq.clj
@@ -1,0 +1,36 @@
+(ns witan.app.mq
+  (:require [witan.application     :as app]
+            [clojure.tools.logging :as log]
+            [clojure.data.json     :as json]
+            [schema.core           :as s]
+            [witan.app.schema      :as ws]))
+
+(defprotocol MQSendMessage
+  (send-message! [this topic message]))
+
+(def topics
+  {:test    "test"
+   :command "command"})
+
+(def commands
+  {:user-invited (merge ws/Username ws/InviteToken)
+   :user-created (merge ws/Username ws/User)})
+
+(defn send-msg!
+  [topic message]
+  (if-let [mq (:mq app/system)]
+    (if-let [topic-str (get topics topic)]
+      (let [msg (if (map? message) (json/write-str message) message)]
+        (send-message! mq topic-str msg))
+      (log/error "Couldn't send message -" topic "is not a valid topic."))
+    (log/error "No message queue available. Topic:" topic)))
+
+(defn send-command!
+  [command args]
+  (if-let [schema (get commands command)]
+    (if-let [error (s/check schema args)]
+      (log/error "Couldn't send command" command "- failed to match the command schema:" error)
+      (send-msg! :command {:command command
+                           :args    args
+                           :time    (java.util.Date.)}))
+    (log/error "Couldn't send command -" command "is not a valid command.")))

--- a/src/witan/app/schema.clj
+++ b/src/witan/app/schema.clj
@@ -16,15 +16,21 @@
   (s/pred
    (fn [s] (re-matches #".*@.*" s))))
 
+(def Username
+  {(s/required-key :username) (s/both (length-greater 5) (is-an-email))})
+
 (def LoginDetails
   "validation for /login"
-  {(s/required-key :username) (s/both (length-greater 5) (is-an-email))
-   (s/required-key :password) (length-greater 5)})
+  (merge Username
+         {(s/required-key :password) (length-greater 5)}))
+
+(def InviteToken
+  {(s/required-key :invite-token) s/Str})
 
 (def SignUp
   (merge LoginDetails
-         {(s/required-key :name) s/Str
-          (s/required-key :invite-token) s/Str}))
+         InviteToken
+         {(s/required-key :name) s/Str}))
 
 (def LoginReturn
   (s/either {(s/required-key :token) s/Str

--- a/src/witan/system.clj
+++ b/src/witan/system.clj
@@ -1,23 +1,28 @@
 (ns witan.system
   (:require [com.stuartsierra.component :as component]
             [witan.app.handler]
-            [ring.adapter.jetty :as jetty]
-            [environ.core :as env]))
+            [ring.adapter.jetty         :as jetty]
+            [environ.core               :as env]
+            [clojure.tools.logging      :as log]
+            [witan.app.config           :as conf]
+            [witan.app.components.kafka :as kafka]))
 
 (defrecord JettyServer [handler port]
-    component/Lifecycle
+  component/Lifecycle
   (start [this]
-    (println "Starting JettyServer")
+    (log/info "Starting JettyServer")
     (assoc this ::server (jetty/run-jetty handler {:port port
                                                    :join? false})))
   (stop [this]
-    (println "Stopping JettyServer")
+    (log/info "Stopping JettyServer")
     (.stop (::server this)) ;; this is the jetty shutdown fn.
     (dissoc this ::server)))
 
 (defn system []
-  (let [port (or (env/env :witan-api-port) 3000)]
-    (-> (component/system-map
-         :jetty-server (->JettyServer #'witan.app.handler/app port)
-         :repl-server  (Object.) ; dummy - replaced when invoked via uberjar.
-         ))))
+  (let [api-port   (or (env/env :witan-api-port) 3000)
+        kafka-ip   (or (conf/kafka :host)        "localhost")
+        kafka-port (or (conf/kafka :port)        9092) ]
+    (component/system-map
+     :jetty-server (->JettyServer #'witan.app.handler/app api-port)
+     :repl-server  (Object.) ; dummy - replaced when invoked via uberjar.
+     :mq           (kafka/new-kafka-producer kafka-ip kafka-port))))


### PR DESCRIPTION
You can now send messages to Kafka as _commands_ via `witan.app.mq/send-command!`
I've also included scripts to get a local Kafka up and running