### PR TITLE
deploy to new production

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,3 +28,15 @@ deployment:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push mastodonc/witan.app
       - ./deploy.sh $DEPLOY_STAGING_IP staging
+  new_production:
+    branch: master
+    commands:
+      - lein clean
+      - lein uberjar
+      - ./prepare-aws-creds
+      - docker build -t mastodonc/witan.app .
+      - docker tag -f mastodonc/witan.app mastodonc/witan.app:latest
+      - docker tag -f mastodonc/witan.app mastodonc/witan.app:git-$(echo $CIRCLE_SHA1 | cut -c1-12)
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker push mastodonc/witan.app
+      - ./deploy.sh $DEPLOY_NEW_PRODUCTION_IP new-production


### PR DESCRIPTION
Circle CI changes to deploy to new production
(environment variable DEPLOY_NEW_PRODUCTION_IP was added to witan.app in circle.ci and contains the elastic ip address for the deployment service on the new stack)