### PR TITLE
Add horrible inline styling for outlook and gmail

### DIFF
--- a/resources/email-templates/reset-your-password.html
+++ b/resources/email-templates/reset-your-password.html
@@ -1,883 +1,395 @@
-
-
-  <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-  <html xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-      <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      <meta name="viewport" content="width=device-width"/>
-
-      <style type="text/css">
-
-/**********************************************
-* Ink v1.0.5 - Copyright 2013 ZURB Inc        *
-**********************************************/
-
-/* Client-specific Styles & Reset */
-
-#outlook a {
-  padding:0;
-}
-
-body{
-  width:100% !important;
-  min-width: 100%;
-  -webkit-text-size-adjust:100%;
-  -ms-text-size-adjust:100%;
-  margin:0;
-  padding:0;
-}
-
-.ExternalClass {
-  width:100%;
-}
-
-.ExternalClass,
-.ExternalClass p,
-.ExternalClass span,
-.ExternalClass font,
-.ExternalClass td,
-.ExternalClass div {
-  line-height: 100%;
-}
-
-#backgroundTable {
-  margin:0;
-  padding:0;
-  width:100% !important;
-  line-height: 100% !important;
-}
-
-img {
-  outline:none;
-  text-decoration:none;
-  -ms-interpolation-mode: bicubic;
-  width: auto;
-  max-width: 100%;
-  float: left;
-  clear: both;
-  display: block;
-}
-
-center {
-  width: 100%;
-  min-width: 580px;
-}
-
-a img {
-  border: none;
-}
-
-p {
-  margin: 0 0 0 10px;
-}
-
-table {
-  border-spacing: 0;
-  border-collapse: collapse;
-}
-
-td {
-  word-break: break-word;
-  -webkit-hyphens: auto;
-  -moz-hyphens: auto;
-  hyphens: auto;
-  border-collapse: collapse !important;
-}
-
-table, tr, td {
-  padding: 0;
-  vertical-align: top;
-  text-align: left;
-}
-
-hr {
-  color: #d9d9d9;
-  background-color: #d9d9d9;
-  height: 1px;
-  border: none;
-}
-
-/* Responsive Grid */
-
-table.body {
-  height: 100%;
-  width: 100%;
-}
-
-table.container {
-  width: 580px;
-  margin: 0 auto;
-  text-align: inherit;
-}
-
-table.row {
-  padding: 0px;
-  width: 100%;
-  position: relative;
-}
-
-table.container table.row {
-  display: block;
-}
-
-td.wrapper {
-  padding: 10px 20px 0px 0px;
-  position: relative;
-}
-
-table.columns,
-table.column {
-  margin: 0 auto;
-}
-
-table.columns td,
-table.column td {
-  padding: 0px 0px 10px;
-}
-
-table.columns td.sub-columns,
-table.column td.sub-columns,
-table.columns td.sub-column,
-table.column td.sub-column {
-  padding-right: 10px;
-}
-
-td.sub-column, td.sub-columns {
-  min-width: 0px;
-}
-
-table.row td.last,
-table.container td.last {
-  padding-right: 0px;
-}
-
-table.one { width: 30px; }
-table.two { width: 80px; }
-table.three { width: 130px; }
-table.four { width: 180px; }
-table.five { width: 230px; }
-table.six { width: 280px; }
-table.seven { width: 330px; }
-table.eight { width: 380px; }
-table.nine { width: 430px; }
-table.ten { width: 480px; }
-table.eleven { width: 530px; }
-table.twelve { width: 580px; }
-
-table.one center { min-width: 30px; }
-table.two center { min-width: 80px; }
-table.three center { min-width: 130px; }
-table.four center { min-width: 180px; }
-table.five center { min-width: 230px; }
-table.six center { min-width: 280px; }
-table.seven center { min-width: 330px; }
-table.eight center { min-width: 380px; }
-table.nine center { min-width: 430px; }
-table.ten center { min-width: 480px; }
-table.eleven center { min-width: 530px; }
-table.twelve center { min-width: 580px; }
-
-table.one .panel center { min-width: 10px; }
-table.two .panel center { min-width: 60px; }
-table.three .panel center { min-width: 110px; }
-table.four .panel center { min-width: 160px; }
-table.five .panel center { min-width: 210px; }
-table.six .panel center { min-width: 260px; }
-table.seven .panel center { min-width: 310px; }
-table.eight .panel center { min-width: 360px; }
-table.nine .panel center { min-width: 410px; }
-table.ten .panel center { min-width: 460px; }
-table.eleven .panel center { min-width: 510px; }
-table.twelve .panel center { min-width: 560px; }
-
-.body .columns td.one,
-.body .column td.one { width: 8.333333%; }
-.body .columns td.two,
-.body .column td.two { width: 16.666666%; }
-.body .columns td.three,
-.body .column td.three { width: 25%; }
-.body .columns td.four,
-.body .column td.four { width: 33.333333%; }
-.body .columns td.five,
-.body .column td.five { width: 41.666666%; }
-.body .columns td.six,
-.body .column td.six { width: 50%; }
-.body .columns td.seven,
-.body .column td.seven { width: 58.333333%; }
-.body .columns td.eight,
-.body .column td.eight { width: 66.666666%; }
-.body .columns td.nine,
-.body .column td.nine { width: 75%; }
-.body .columns td.ten,
-.body .column td.ten { width: 83.333333%; }
-.body .columns td.eleven,
-.body .column td.eleven { width: 91.666666%; }
-.body .columns td.twelve,
-.body .column td.twelve { width: 100%; }
-
-td.offset-by-one { padding-left: 50px; }
-td.offset-by-two { padding-left: 100px; }
-td.offset-by-three { padding-left: 150px; }
-td.offset-by-four { padding-left: 200px; }
-td.offset-by-five { padding-left: 250px; }
-td.offset-by-six { padding-left: 300px; }
-td.offset-by-seven { padding-left: 350px; }
-td.offset-by-eight { padding-left: 400px; }
-td.offset-by-nine { padding-left: 450px; }
-td.offset-by-ten { padding-left: 500px; }
-td.offset-by-eleven { padding-left: 550px; }
-
-td.expander {
-  visibility: hidden;
-  width: 0px;
-  padding: 0 !important;
-}
-
-table.columns .text-pad,
-table.column .text-pad {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-table.columns .left-text-pad,
-table.columns .text-pad-left,
-table.column .left-text-pad,
-table.column .text-pad-left {
-  padding-left: 10px;
-}
-
-table.columns .right-text-pad,
-table.columns .text-pad-right,
-table.column .right-text-pad,
-table.column .text-pad-right {
-  padding-right: 10px;
-}
-
-/* Block Grid */
-
-.block-grid {
-  width: 100%;
-  max-width: 580px;
-}
-
-.block-grid td {
-  display: inline-block;
-  padding:10px;
-}
-
-.two-up td {
-  width:270px;
-}
-
-.three-up td {
-  width:173px;
-}
-
-.four-up td {
-  width:125px;
-}
-
-.five-up td {
-  width:96px;
-}
-
-.six-up td {
-  width:76px;
-}
-
-.seven-up td {
-  width:62px;
-}
-
-.eight-up td {
-  width:52px;
-}
-
-/* Alignment & Visibility Classes */
-
-table.center, td.center {
-  text-align: center;
-}
-
-h1.center,
-h2.center,
-h3.center,
-h4.center,
-h5.center,
-h6.center {
-  text-align: center;
-}
-
-span.center {
-  display: block;
-  width: 100%;
-  text-align: center;
-}
-
-img.center {
-  margin: 0 auto;
-  float: none;
-}
-
-.show-for-small,
-.hide-for-desktop {
-  display: none;
-}
-
-/* Typography */
-
-body, table.body, h1, h2, h3, h4, h5, h6, p, td {
-  color: #222222;
-  font-family: "Helvetica", "Arial", sans-serif;
-  font-weight: normal;
-  padding:0;
-  margin: 0;
-  text-align: left;
-  line-height: 1.3;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  word-break: normal;
-}
-
-h1 {font-size: 40px;}
-h2 {font-size: 36px;}
-h3 {font-size: 32px;}
-h4 {font-size: 28px;}
-h5 {font-size: 24px;}
-h6 {font-size: 20px;}
-body, table.body, p, td {font-size: 14px;line-height:19px;}
-
-p.lead, p.lede, p.leed {
-  font-size: 18px;
-  line-height:21px;
-}
-
-p {
-  margin-bottom: 10px;
-}
-
-small {
-  font-size: 10px;
-}
-
-a {
-  color: #2ba6cb;
-  text-decoration: none;
-}
-
+<!-- Inliner Build Version 4380b7741bb759d6cb997545f3add21ad48f010b -->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width" />
+  </head>
+  <body style="width: 100% !important; min-width: 100%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: left; line-height: 19px; font-size: 14px; margin: 0; padding: 0;"><style type="text/css">
 a:hover {
-  color: #2795b6 !important;
+color: #2795b6 !important;
 }
-
 a:active {
-  color: #2795b6 !important;
+color: #2795b6 !important;
 }
-
 a:visited {
-  color: #2ba6cb !important;
+color: #2ba6cb !important;
 }
-
-h1 a,
-h2 a,
-h3 a,
-h4 a,
-h5 a,
-h6 a {
-  color: #2ba6cb;
+h1 a:active {
+color: #2ba6cb !important;
 }
-
-h1 a:active,
-h2 a:active,
-h3 a:active,
-h4 a:active,
-h5 a:active,
+h2 a:active {
+color: #2ba6cb !important;
+}
+h3 a:active {
+color: #2ba6cb !important;
+}
+h4 a:active {
+color: #2ba6cb !important;
+}
+h5 a:active {
+color: #2ba6cb !important;
+}
 h6 a:active {
-  color: #2ba6cb !important;
+color: #2ba6cb !important;
 }
-
-h1 a:visited,
-h2 a:visited,
-h3 a:visited,
-h4 a:visited,
-h5 a:visited,
+h1 a:visited {
+color: #2ba6cb !important;
+}
+h2 a:visited {
+color: #2ba6cb !important;
+}
+h3 a:visited {
+color: #2ba6cb !important;
+}
+h4 a:visited {
+color: #2ba6cb !important;
+}
+h5 a:visited {
+color: #2ba6cb !important;
+}
 h6 a:visited {
-  color: #2ba6cb !important;
+color: #2ba6cb !important;
 }
-
-/* Panels */
-
-.panel {
-  background: #f2f2f2;
-  border: 1px solid #d9d9d9;
-  padding: 10px !important;
+table.button:hover td {
+background: #2795b6 !important;
 }
-
-.sub-grid table {
-  width: 100%;
+table.button:visited td {
+background: #2795b6 !important;
 }
-
-.sub-grid td.sub-columns {
-  padding-bottom: 0;
-}
-
-/* Buttons */
-
-table.button,
-table.tiny-button,
-table.small-button,
-table.medium-button,
-table.large-button {
-  width: 100%;
-  overflow: hidden;
-}
-
-table.button td,
-table.tiny-button td,
-table.small-button td,
-table.medium-button td,
-table.large-button td {
-  display: block;
-  width: auto !important;
-  text-align: center;
-  background: #2ba6cb;
-  border: 1px solid #2284a1;
-  color: #ffffff;
-  padding: 8px 0;
-}
-
-table.tiny-button td {
-  padding: 5px 0 4px;
-}
-
-table.small-button td {
-  padding: 8px 0 7px;
-}
-
-table.medium-button td {
-  padding: 12px 0 10px;
-}
-
-table.large-button td {
-  padding: 21px 0 18px;
-}
-
-table.button td a,
-table.tiny-button td a,
-table.small-button td a,
-table.medium-button td a,
-table.large-button td a {
-  font-weight: bold;
-  text-decoration: none;
-  font-family: Helvetica, Arial, sans-serif;
-  color: #ffffff;
-  font-size: 16px;
-}
-
-table.tiny-button td a {
-  font-size: 12px;
-  font-weight: normal;
-}
-
-table.small-button td a {
-  font-size: 16px;
-}
-
-table.medium-button td a {
-  font-size: 20px;
-}
-
-table.large-button td a {
-  font-size: 24px;
-}
-
-table.button:hover td,
-table.button:visited td,
 table.button:active td {
-  background: #2795b6 !important;
+background: #2795b6 !important;
 }
-
-table.button:hover td a,
-table.button:visited td a,
+table.button:hover td a {
+color: #fff !important;
+}
+table.button:visited td a {
+color: #fff !important;
+}
 table.button:active td a {
-  color: #fff !important;
+color: #fff !important;
 }
-
-table.button:hover td,
-table.tiny-button:hover td,
-table.small-button:hover td,
-table.medium-button:hover td,
+table.button:hover td {
+background: #2795b6 !important;
+}
+table.tiny-button:hover td {
+background: #2795b6 !important;
+}
+table.small-button:hover td {
+background: #2795b6 !important;
+}
+table.medium-button:hover td {
+background: #2795b6 !important;
+}
 table.large-button:hover td {
-  background: #2795b6 !important;
+background: #2795b6 !important;
 }
-
-table.button:hover td a,
-table.button:active td a,
-table.button td a:visited,
-table.tiny-button:hover td a,
-table.tiny-button:active td a,
-table.tiny-button td a:visited,
-table.small-button:hover td a,
-table.small-button:active td a,
-table.small-button td a:visited,
-table.medium-button:hover td a,
-table.medium-button:active td a,
-table.medium-button td a:visited,
-table.large-button:hover td a,
-table.large-button:active td a,
+table.button:hover td a {
+color: #ffffff !important;
+}
+table.button:active td a {
+color: #ffffff !important;
+}
+table.button td a:visited {
+color: #ffffff !important;
+}
+table.tiny-button:hover td a {
+color: #ffffff !important;
+}
+table.tiny-button:active td a {
+color: #ffffff !important;
+}
+table.tiny-button td a:visited {
+color: #ffffff !important;
+}
+table.small-button:hover td a {
+color: #ffffff !important;
+}
+table.small-button:active td a {
+color: #ffffff !important;
+}
+table.small-button td a:visited {
+color: #ffffff !important;
+}
+table.medium-button:hover td a {
+color: #ffffff !important;
+}
+table.medium-button:active td a {
+color: #ffffff !important;
+}
+table.medium-button td a:visited {
+color: #ffffff !important;
+}
+table.large-button:hover td a {
+color: #ffffff !important;
+}
+table.large-button:active td a {
+color: #ffffff !important;
+}
 table.large-button td a:visited {
-  color: #ffffff !important;
+color: #ffffff !important;
 }
-
-table.secondary td {
-  background: #e9e9e9;
-  border-color: #d0d0d0;
-  color: #555;
-}
-
-table.secondary td a {
-  color: #555;
-}
-
 table.secondary:hover td {
-  background: #d0d0d0 !important;
-  color: #555;
+background: #d0d0d0 !important; color: #555;
 }
-
-table.secondary:hover td a,
-table.secondary td a:visited,
+table.secondary:hover td a {
+color: #555 !important;
+}
+table.secondary td a:visited {
+color: #555 !important;
+}
 table.secondary:active td a {
-  color: #555 !important;
+color: #555 !important;
 }
-
-table.success td {
-  background: #5da423;
-  border-color: #457a1a;
-}
-
 table.success:hover td {
-  background: #457a1a !important;
+background: #457a1a !important;
 }
-
-table.alert td {
-  background: #c60f13;
-  border-color: #970b0e;
-}
-
 table.alert:hover td {
-  background: #970b0e !important;
+background: #970b0e !important;
 }
-
-table.radius td {
-  -webkit-border-radius: 3px;
-  -moz-border-radius: 3px;
-  border-radius: 3px;
+table.button:hover td {
+background: #0065bc !important;
 }
-
-table.round td {
-  -webkit-border-radius: 500px;
-  -moz-border-radius: 500px;
-  border-radius: 500px;
+table.button:visited td {
+background: #0065bc !important;
 }
-
-/* Outlook First */
-
-body.outlook p {
-  display: inline !important;
+table.button:active td {
+background: #0065bc !important;
 }
-
-/*  Media Queries */
-
+a:hover {
+color: #0074d9 !important; text-decoration: underline;
+}
+a:focus {
+color: #0074d9 !important; text-decoration: underline;
+}
+a:active {
+color: #0074d9 !important; text-decoration: underline;
+}
+a:visited {
+color: #0074d9 !important; text-decoration: underline;
+}
 @media only screen and (max-width: 600px) {
-
   table[class="body"] img {
-    width: auto !important;
-    height: auto !important;
+    width: auto !important; height: auto !important;
   }
-
   table[class="body"] center {
     min-width: 0 !important;
   }
-
   table[class="body"] .container {
     width: 95% !important;
   }
-
   table[class="body"] .row {
-    width: 100% !important;
-    display: block !important;
+    width: 100% !important; display: block !important;
   }
-
   table[class="body"] .wrapper {
-    display: block !important;
-    padding-right: 0 !important;
+    display: block !important; padding-right: 0 !important;
   }
-
-  table[class="body"] .columns,
+  table[class="body"] .columns {
+    table-layout: fixed !important; float: none !important; width: 100% !important; padding-right: 0px !important; padding-left: 0px !important; display: block !important;
+  }
   table[class="body"] .column {
-    table-layout: fixed !important;
-    float: none !important;
-    width: 100% !important;
-    padding-right: 0px !important;
-    padding-left: 0px !important;
-    display: block !important;
+    table-layout: fixed !important; float: none !important; width: 100% !important; padding-right: 0px !important; padding-left: 0px !important; display: block !important;
   }
-
-  table[class="body"] .wrapper.first .columns,
+  table[class="body"] .wrapper.first .columns {
+    display: table !important;
+  }
   table[class="body"] .wrapper.first .column {
     display: table !important;
   }
-
-  table[class="body"] table.columns td,
+  table[class="body"] table.columns td {
+    width: 100% !important;
+  }
   table[class="body"] table.column td {
     width: 100% !important;
   }
-
-  table[class="body"] .columns td.one,
-  table[class="body"] .column td.one { width: 8.333333% !important; }
-  table[class="body"] .columns td.two,
-  table[class="body"] .column td.two { width: 16.666666% !important; }
-  table[class="body"] .columns td.three,
-  table[class="body"] .column td.three { width: 25% !important; }
-  table[class="body"] .columns td.four,
-  table[class="body"] .column td.four { width: 33.333333% !important; }
-  table[class="body"] .columns td.five,
-  table[class="body"] .column td.five { width: 41.666666% !important; }
-  table[class="body"] .columns td.six,
-  table[class="body"] .column td.six { width: 50% !important; }
-  table[class="body"] .columns td.seven,
-  table[class="body"] .column td.seven { width: 58.333333% !important; }
-  table[class="body"] .columns td.eight,
-  table[class="body"] .column td.eight { width: 66.666666% !important; }
-  table[class="body"] .columns td.nine,
-  table[class="body"] .column td.nine { width: 75% !important; }
-  table[class="body"] .columns td.ten,
-  table[class="body"] .column td.ten { width: 83.333333% !important; }
-  table[class="body"] .columns td.eleven,
-  table[class="body"] .column td.eleven { width: 91.666666% !important; }
-  table[class="body"] .columns td.twelve,
-  table[class="body"] .column td.twelve { width: 100% !important; }
-
-  table[class="body"] td.offset-by-one,
-  table[class="body"] td.offset-by-two,
-  table[class="body"] td.offset-by-three,
-  table[class="body"] td.offset-by-four,
-  table[class="body"] td.offset-by-five,
-  table[class="body"] td.offset-by-six,
-  table[class="body"] td.offset-by-seven,
-  table[class="body"] td.offset-by-eight,
-  table[class="body"] td.offset-by-nine,
-  table[class="body"] td.offset-by-ten,
+  table[class="body"] .columns td.one {
+    width: 8.333333% !important;
+  }
+  table[class="body"] .column td.one {
+    width: 8.333333% !important;
+  }
+  table[class="body"] .columns td.two {
+    width: 16.666666% !important;
+  }
+  table[class="body"] .column td.two {
+    width: 16.666666% !important;
+  }
+  table[class="body"] .columns td.three {
+    width: 25% !important;
+  }
+  table[class="body"] .column td.three {
+    width: 25% !important;
+  }
+  table[class="body"] .columns td.four {
+    width: 33.333333% !important;
+  }
+  table[class="body"] .column td.four {
+    width: 33.333333% !important;
+  }
+  table[class="body"] .columns td.five {
+    width: 41.666666% !important;
+  }
+  table[class="body"] .column td.five {
+    width: 41.666666% !important;
+  }
+  table[class="body"] .columns td.six {
+    width: 50% !important;
+  }
+  table[class="body"] .column td.six {
+    width: 50% !important;
+  }
+  table[class="body"] .columns td.seven {
+    width: 58.333333% !important;
+  }
+  table[class="body"] .column td.seven {
+    width: 58.333333% !important;
+  }
+  table[class="body"] .columns td.eight {
+    width: 66.666666% !important;
+  }
+  table[class="body"] .column td.eight {
+    width: 66.666666% !important;
+  }
+  table[class="body"] .columns td.nine {
+    width: 75% !important;
+  }
+  table[class="body"] .column td.nine {
+    width: 75% !important;
+  }
+  table[class="body"] .columns td.ten {
+    width: 83.333333% !important;
+  }
+  table[class="body"] .column td.ten {
+    width: 83.333333% !important;
+  }
+  table[class="body"] .columns td.eleven {
+    width: 91.666666% !important;
+  }
+  table[class="body"] .column td.eleven {
+    width: 91.666666% !important;
+  }
+  table[class="body"] .columns td.twelve {
+    width: 100% !important;
+  }
+  table[class="body"] .column td.twelve {
+    width: 100% !important;
+  }
+  table[class="body"] td.offset-by-one {
+    padding-left: 0 !important;
+  }
+  table[class="body"] td.offset-by-two {
+    padding-left: 0 !important;
+  }
+  table[class="body"] td.offset-by-three {
+    padding-left: 0 !important;
+  }
+  table[class="body"] td.offset-by-four {
+    padding-left: 0 !important;
+  }
+  table[class="body"] td.offset-by-five {
+    padding-left: 0 !important;
+  }
+  table[class="body"] td.offset-by-six {
+    padding-left: 0 !important;
+  }
+  table[class="body"] td.offset-by-seven {
+    padding-left: 0 !important;
+  }
+  table[class="body"] td.offset-by-eight {
+    padding-left: 0 !important;
+  }
+  table[class="body"] td.offset-by-nine {
+    padding-left: 0 !important;
+  }
+  table[class="body"] td.offset-by-ten {
+    padding-left: 0 !important;
+  }
   table[class="body"] td.offset-by-eleven {
     padding-left: 0 !important;
   }
-
   table[class="body"] table.columns td.expander {
     width: 1px !important;
   }
-
-  table[class="body"] .right-text-pad,
+  table[class="body"] .right-text-pad {
+    padding-left: 10px !important;
+  }
   table[class="body"] .text-pad-right {
     padding-left: 10px !important;
   }
-
-  table[class="body"] .left-text-pad,
+  table[class="body"] .left-text-pad {
+    padding-right: 10px !important;
+  }
   table[class="body"] .text-pad-left {
     padding-right: 10px !important;
   }
-
-  table[class="body"] .hide-for-small,
+  table[class="body"] .hide-for-small {
+    display: none !important;
+  }
   table[class="body"] .show-for-desktop {
     display: none !important;
   }
-
-  table[class="body"] .show-for-small,
+  table[class="body"] .show-for-small {
+    display: inherit !important;
+  }
   table[class="body"] .hide-for-desktop {
     display: inherit !important;
   }
 }
-
-      </style>
-      <style type="text/css">
-
-table.button td,
-table.tiny-button td,
-table.small-button td,
-table.medium-button td,
-table.large-button td {
-  display: block;
-  width: auto !important;
-  text-align: center;
-  background:#0074d9;
-  color: #ffffff;
-  padding: 8px 0;
-}
-
-table.button:hover td,
-table.button:visited td,
-table.button:active td {
-  background: #0065bc !important;
-}
-
-a {
-  color:#0074d9;
-}
-
-a:hover, a:focus, a:active, a:visited {
-  color:#0074d9 !important;
-  text-decoration: underline;
-}
-
-code {
-  padding:2px 4px;
-  font-size:90%;
-  color:#c7254e;
-  background-color:#f9f2f4;
-  border-radius:4px;
-}
-
-blockquote {
-  padding:10px 20px;
-  margin:0 0 20px;
-  font-size:18px;
-  border-left:5px solid #eee;
-}
-blockquote p {
-  font-size:18px;
-}
-ol, ul {
-  margin:0 0 30px 0;
-}
-hr {
-  margin: 30px 0;
-}
-center>h1, center>h2, center>h3, center>h4, center>h5, center>h6, center>p {
-  text-align: center;
-}
-h1 {
-  font-size: 36px;
-  line-height: 1.5;
-  font-weight: bold;
-  padding-bottom:15px;
-}
-h1 small, h2 small, h3 small, h4 small, h5 small, h6 small {
-  font-size:65%;
-  color:#777;
-  font-weight: normal;
-  display: block;
-}
-
-h2 {
-  font-size: 30px;
-  line-height: 1.5;
-  font-weight: bold;
-  padding-bottom:10px;
-}
-
-h3 {
-  font-size: 24px;
-  line-height: 1.5;
-  font-weight: bold;
-  padding-bottom:10px;
-}
-
-h4 {
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: bold;
-  padding-bottom:10px;
-}
-
-h5 {
-  font-size: 14px;
-  line-height: 1.5;
-  font-weight: bold;
-  padding-bottom:10px;
-}
-
-h6 {
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: bold;
-}
-p {
-  line-height: 1.5;
-}
-img {
-  width: 100%;
-}
-
-      </style>
-    </head>
-    <body>
-      <table class="body">
-        <tr>
-          <td class="center" align="center" valign="top">
-            <center>
+</style>
+      <table class="body" style="border-spacing: 0; border-collapse: collapse; vertical-align: top; text-align: left; height: 100%; width: 100%; color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; line-height: 19px; font-size: 14px; margin: 0; padding: 0;"><tr style="vertical-align: top; text-align: left; padding: 0;" align="left"><td class="center" align="center" valign="top" style="word-break: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto; border-collapse: collapse !important; vertical-align: top; text-align: center; color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; line-height: 19px; font-size: 14px; margin: 0; padding: 0;">
+            <center style="width: 100%; min-width: 580px;">
 
 
-  <table class="body" style="margin:20px auto;">
-    <tbody><tr>
-      <td class="center" align="center" valign="top">
-        <center>
+  <table class="body" style="border-spacing: 0; border-collapse: collapse; vertical-align: top; text-align: left; height: 100%; width: 100%; color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; line-height: 19px; font-size: 14px; margin: 20px auto; padding: 0;"><tbody><tr style="vertical-align: top; text-align: left; padding: 0;" align="left"><td class="center" align="center" valign="top" style="word-break: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto; border-collapse: collapse !important; vertical-align: top; text-align: center; color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; line-height: 19px; font-size: 14px; margin: 0; padding: 0;">
+        <center style="width: 100%; min-width: 580px;">
 
-          <table class="container">
-          <tbody>
-          <tr>
-          <td>
-  <p></p><center><p></p>
+          <table class="container" style="border-spacing: 0; border-collapse: collapse; vertical-align: top; text-align: inherit; width: 580px; margin: 0 auto; padding: 0;"><tbody><tr style="vertical-align: top; text-align: left; padding: 0;" align="left"><td style="word-break: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto; border-collapse: collapse !important; vertical-align: top; text-align: left; color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; line-height: 19px; font-size: 14px; margin: 0; padding: 0;" align="left" valign="top">
+  <p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: left; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="left"></p><center style="width: 100%; min-width: 580px;"><p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: center; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="center"></p>
 
-<h3>Witan<small>Make sense of your city</small></h3>
+<h3 style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: bold; text-align: center; line-height: 1.5; word-break: normal; font-size: 24px; margin: 0; padding: 0 0 10px;" align="center">Witan</h3>
+              <h3 style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: bold; text-align: center; line-height: 1.5; word-break: normal; font-size: 24px; margin: 0; padding: 0 0 10px;" align="center">
+                  <small style="font-size: 65%; color: #777; font-weight: normal; display: block;">Make sense of your city</small>
+              </h3>
 
 
-<hr>
+<hr style="color: #d9d9d9; height: 1px; background: #d9d9d9; margin: 30px 0; border: none;" /><h2 style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: bold; text-align: center; line-height: 1.5; word-break: normal; font-size: 30px; margin: 0; padding: 0 0 10px;" align="center">Reset your password</h2>
+              <h2 style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: bold; text-align: center; line-height: 1.5; word-break: normal; font-size: 30px; margin: 0; padding: 0 0 10px;" align="center">
+                  <small style="font-size: 65%; color: #777; font-weight: normal; display: block;">Forgot your password? Don't worry, it happens to all of us.</small>
+              </h2>
 
-<h2>Reset your password <small>Forgot your password? Don't worry, it happens to all of us.</small></h2>
+              <br />
 
-<p></p></center><p></p>
+<p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: center; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="center"></p></center><p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: left; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="left"></p>
 
-<p>We've received a request to reset your password for using Witan. If you follow the link below, you can reset your password.</p>
+<p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: left; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="left">We've received a request to reset your password for using Witan. If you follow the link below, you can reset your password.</p>
 
-<p>Once you have done this, you can then sign in with your email address, and your new password, and be back on your way.</p>
+<p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: left; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="left">Once you have done this, you can then sign in with your email address, and your new password, and be back on your way.</p>
 
-<p></p><table class="button radius"><tbody><tr><td>
-<a href="http://{{ link_to_reset_password  }}" title="Reset my password">Reset my password for Witan</a>
-</td></tr></tbody></table><p></p>
+                                          <br />
 
-<hr>
+<p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: left; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="left"></p><table class="button radius" style="border-spacing: 0; border-collapse: collapse; vertical-align: top; text-align: left; width: 100%; overflow: hidden; padding: 0;"><tbody><tr style="vertical-align: top; text-align: left; padding: 0;" align="left"><td style="word-break: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto; border-collapse: collapse !important; vertical-align: top; text-align: center; color: #ffffff; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; line-height: 19px; font-size: 14px; display: block; width: auto !important; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px; background: #0074d9; margin: 0; padding: 8px 0; border: 1px solid #2284a1;" align="center" bgcolor="#0074d9" valign="top">
+<a href="http://{{ link_to_reset_password  }}" title="Reset my password" style="color: #ffffff; text-decoration: none; font-weight: bold; font-family: Helvetica, Arial, sans-serif; font-size: 16px;">Reset my password for Witan</a>
+</td></tr></tbody></table><p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: left; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="left"></p>
 
-<p></p><center>
+                            <br />
+
 <em>If you didn't request a password, you can ignore this email. Your password will only be changed if you follow the link above.</em>
-</center><p></p>
+</center><p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: left; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="left"></p>
 
-<hr>
+<hr style="color: #d9d9d9; height: 1px; background: #d9d9d9; margin: 30px 0; border: none;" /><h4 style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: bold; text-align: left; line-height: 1.5; word-break: normal; font-size: 18px; margin: 0; padding: 0 0 10px;" align="left">Need more help?</h4>
 
-<h4>Need more help?</h4>
-
-<p>If you're stuck, our support team is just an email away - just reply to this message, or send an email to <a mailto="witan@mastodonc.com">witan@mastodonc.com</a>.</p>
+<p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: left; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="left">If you're stuck, our support team is just an email away - just reply to this message, or send an email to <a mailto="witan@mastodonc.com" style="color: #0074d9; text-decoration: none;">witan@mastodonc.com</a>.</p>
 
 
 
-<hr>
+<hr style="color: #d9d9d9; height: 1px; background: #d9d9d9; margin: 30px 0; border: none;" /><p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: left; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="left"></p><center style="width: 100%; min-width: 580px;"><p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: center; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="center"></p>
 
-<p></p><center><p></p>
-
-<p><a href="http://# Witan">witan-alpha.mastodonc.com</a>
-</p></center><p></p>
+<p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: center; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="center"><a href="http://# Witan" style="color: #0074d9; text-decoration: none;">witan-alpha.mastodonc.com</a>
+</p></center><p style="color: #222222; font-family: 'Helvetica', 'Arial', sans-serif; font-weight: normal; text-align: left; line-height: 1.5; font-size: 14px; margin: 0 0 10px; padding: 0;" align="left"></p>
           </td>
-          </tr>
-          </tbody>
-          </table>
-
-        </center>
+          </tr></tbody></table></center>
       </td>
-    </tr>
-  </tbody></table>
-
-
-            </center>
+    </tr></tbody></table></center>
           </td>
-        </tr>
-      </table>
-    </body>
-  </html>
+        </tr></table></body>
+</html>


### PR DESCRIPTION
I've used [inliner][], and [litmus][] to check how the HTML emails look in Google Chrome and Outlook 2013, the two most awkward of the popular email clients.

This makes the html look even messier than it did before, as the styles need to be declared inline.

[inliner]: http://foundation.zurb.com/emails/inliner.html
[litmus]: https://litmus.com