### PR TITLE
Update header validation

### DIFF
--- a/src/witan/validation.clj
+++ b/src/witan/validation.clj
@@ -20,7 +20,7 @@
 
 (defn category-validation-error?
   [category lines]
-  (let [req-headers #{"gss.code.borough" "gss.code.ward" "ward.name"}
+  (let [req-headers #{"gss.code.borough" "gss.code.ward" "borough" "ward.name"}
         inc-headers (str/split (first lines) #",")
         formatted-headers (->> inc-headers
                                (map str/lower-case)

--- a/test/witan/validation_test.clj
+++ b/test/witan/validation_test.clj
@@ -17,7 +17,7 @@
   (testing "header validation failed"
     (let [validated (validate-content "development-data" (io/file "test-data/bad-header.csv"))]
       (is (not (first validated)))
-      (is (= "The header row of the file is missing one or more required rows. We expect ward.name,gss.code.ward,gss.code.borough" (validation-error validated)))))
+      (is (= "The header row of the file is missing one or more required rows. We expect ward.name,borough,gss.code.ward,gss.code.borough" (validation-error validated)))))
 
   (testing "validation ok"
     (let [validated (validate-content "development-data" (io/file "test-data/Template_DevelopmentData_Bexley_WithData.csv"))]


### PR DESCRIPTION
Encountered some data in the wild using "Borough Name" as a column header. This was slipping through validation and resulting in an error for users. The correct name for the column should be "Borough".